### PR TITLE
Avoid null pointer exception on blog views component

### DIFF
--- a/components/Views.php
+++ b/components/Views.php
@@ -48,14 +48,16 @@ class Views extends ComponentBase
     {
         $out = 0;
         $post = $this->loadPost();
+        
+        if(!is_null($post)) {
+            $obj = Db::table('vdomah_blogviews_views')
+                ->where('post_id', $post->getKey());
 
-        $obj = Db::table('vdomah_blogviews_views')
-            ->where('post_id', $post->getKey());
-
-        if ($obj->count() > 0) {
-            $out = $obj->first()->views;
+            if ($obj->count() > 0) {
+                $out = $obj->first()->views;
+            }
         }
-
+        
         return $out;
     }
 }


### PR DESCRIPTION
The blog views component could encounter a null pointer exception if it
got invoked with a post that did not exist or was not published. This
puts in a check to verify that the post is not null first to avoid getkey() on NULL error.