### PR TITLE
Optimized getting the number of views of posts from the database

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -95,12 +95,9 @@ class Plugin extends PluginBase
         PostModel::extend(function($model) {
             $model->addDynamicMethod('getViewsAttribute', function() use ($model) {
                 $obj = Db::table('vdomah_blogviews_views')
-                    ->where('post_id', $model->getKey());
+                    ->where('post_id', $model->getKey())->first();
 
-                $out = 0;
-                if ($obj->count() > 0) {
-                    $out = $obj->first()->views;
-                }
+                $out = is_null($obj) ? 0 : $obj->views;
 
                 return $out;
             });


### PR DESCRIPTION
In the previous version there were two calls to the database. The first time at $ obj-> count () to find out if there are records in the database and the second time $ obj-> first () -> vievs to get the object.
In the proposed version, one call to the database occurs and it is checked whether the object is received.

The proposed option reduces the number of queries to the database to get the number of views in half.

Sorry for the mistakes, I use Google translator)